### PR TITLE
feat: support generic HTTPS git URLs with Gitea token auth fix

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -50,7 +50,7 @@ clone_from_git() {
   local git_token="${GIT_TOKEN:-$GITHUB_TOKEN}"
 
   if [ -n "$git_token" ]; then
-    git clone $clone_opts "https://${git_token}@${git_host}/${repo_path}.git" /usercontent
+    git clone $clone_opts "https://token:${git_token}@${git_host}/${repo_path}.git" /usercontent
   else
     git clone $clone_opts "https://${git_host}/${repo_path}.git" /usercontent
   fi


### PR DESCRIPTION
## Summary
- Supports cloning from any HTTPS git host (GitHub, Gitea, GitLab, Bitbucket, etc.) instead of only GitHub
- Fixes Gitea token authentication by using `token:TOKEN@host` format instead of `TOKEN@host` — Gitea requires the `token` username prefix for HTTP Basic Auth, while the old format caused `could not read Password` errors in non-interactive containers

## Test plan
- [ ] Deploy a Python app from a GitHub repo with a PAT — verify clone succeeds
- [ ] Deploy a Python app from a Gitea repo with an API token — verify clone succeeds
- [ ] Deploy a Python app from a public repo without any token — verify clone succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)