### PR TITLE
fix: scrub PAT from git origin remote after clone

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -54,6 +54,11 @@ clone_from_git() {
   else
     git clone $clone_opts "https://${git_host}/${repo_path}.git" /usercontent
   fi
+
+  # Scrub PAT from origin remote — token must not persist to .git/config
+  if [ -n "$git_token" ]; then
+    git -C /usercontent remote set-url origin "https://${git_host}/${repo_path}.git"
+  fi
 }
 
 # Write commit metadata to a well-known file for platform visibility


### PR DESCRIPTION
## Summary

After a successful git clone with a token-embedded URL, the token is stored persistently in \`.git/config\`. This PR adds a \`git remote set-url\` call immediately after every clone to strip the credentials from the stored origin URL.

## Change

In \`scripts/docker-entrypoint.sh\`, inside \`clone_from_git()\` after the clone block:
\`\`\`bash
# Scrub PAT from origin remote — token must not persist to .git/config
if [ -n "\$git_token" ]; then
  git -C /usercontent remote set-url origin "https://\${git_host}/\${repo_path}.git"
fi
\`\`\`

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)