### PR TITLE
Strip embedded credentials from GIT_HOST to prevent PAT leak

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -16,8 +16,12 @@ clone_from_git() {
   local branch=""
   local repo_path=""
 
-  # Extract hostname dynamically from URL
+  # Extract hostname dynamically from URL (may include user:pass@ for Gitea-style URLs)
   local git_host=$(echo "$url" | sed -E 's|https?://([^/]+).*|\1|')
+  # Variant with any embedded credentials stripped — used for log lines and the
+  # persisted remote URL so that PATs never leak into pod logs or .git/config.
+  # When SOURCE_URL has no credentials, this is identical to git_host.
+  local git_host_public=$(echo "$git_host" | sed -E 's|^[^@]+@||')
 
   # Check if URL contains a branch reference (e.g., /tree/branch_name)
   if [[ "$url" == *"/tree/"* ]]; then
@@ -32,9 +36,9 @@ clone_from_git() {
   fi
 
   if [ -n "$branch" ]; then
-    echo "Cloning repository: $repo_path (branch: $branch) from $git_host"
+    echo "Cloning repository: $repo_path (branch: $branch) from $git_host_public"
   else
-    echo "Cloning repository: $repo_path from $git_host"
+    echo "Cloning repository: $repo_path from $git_host_public"
   fi
 
   # Clear the usercontent directory
@@ -50,15 +54,20 @@ clone_from_git() {
   local git_token="${GIT_TOKEN:-$GITHUB_TOKEN}"
 
   if [ -n "$git_token" ]; then
-    git clone $clone_opts "https://token:${git_token}@${git_host}/${repo_path}.git" /usercontent
-  else
+    echo "cloning https://***@${git_host_public}/${repo_path}.git"
+    git clone $clone_opts "https://token:${git_token}@${git_host_public}/${repo_path}.git" /usercontent
+  elif [ "$git_host" != "$git_host_public" ]; then
+    # SOURCE_URL embeds credentials (e.g. Gitea: https://user:pass@host/...).
+    # Clone with them in place but keep them out of the log line.
+    echo "cloning https://***@${git_host_public}/${repo_path}.git"
     git clone $clone_opts "https://${git_host}/${repo_path}.git" /usercontent
+  else
+    echo "cloning https://${git_host_public}/${repo_path}.git"
+    git clone $clone_opts "https://${git_host_public}/${repo_path}.git" /usercontent
   fi
 
   # Scrub PAT from origin remote — token must not persist to .git/config
-  if [ -n "$git_token" ]; then
-    git -C /usercontent remote set-url origin "https://${git_host}/${repo_path}.git"
-  fi
+  git -C /usercontent remote set-url origin "https://${git_host_public}/${repo_path}.git"
 }
 
 # Write commit metadata to a well-known file for platform visibility

--- a/tests/test-entrypoint-credential-scrub.sh
+++ b/tests/test-entrypoint-credential-scrub.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tests/test-entrypoint-credential-scrub.sh
+#
+# Shell regression tests for the credential-scrub fix in scripts/docker-entrypoint.sh.
+#
+# Background:
+#   When SOURCE_URL embeds credentials (https://user:pass@host/path.git), the
+#   pattern used by Gitea-backed apps, the host extraction
+#       git_host=$(echo "$url" | sed -E 's|https?://([^/]+).*|\1|')
+#   yields "user:pass@host" — i.e. credentials remain in git_host.
+#
+#   Before this fix the clone_from_git() function echoed the credentialed host
+#   into pod logs and, crucially, persisted the credentialed URL into .git/config
+#   because the "scrub" line
+#       git -C /usercontent remote set-url origin "https://${git_host}/${repo_path}.git"
+#   reconstructed the same URL it was supposed to remove.
+#
+# Fix (this PR):
+#   Introduce git_host_public=$(echo "$git_host" | sed -E 's|^[^@]+@||') — a
+#   sanitized variant used in log lines and the persisted remote URL. git_host
+#   keeps any embedded creds for the clone itself when no separate $GIT_TOKEN is
+#   provided. When SOURCE_URL has no credentials, git_host_public == git_host
+#   and behavior is unchanged.
+#
+# Reference fix: https://github.com/Eyevinn/web-runner/pull/37
+#
+# These tests grep the entrypoint to assert the fix has not regressed.
+
+ENTRYPOINT="scripts/docker-entrypoint.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: git_host_public is derived from git_host with embedded creds stripped
+# ---------------------------------------------------------------------------
+if grep -qE 'git_host_public=\$\(echo "\$git_host" \| sed -E' "$ENTRYPOINT"; then
+  pass "git_host_public strips user:pass@ from git_host using sed"
+else
+  fail "git_host_public assignment is missing or does not strip embedded creds"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: persisted remote URL uses the scrubbed host
+# ---------------------------------------------------------------------------
+if grep -qE 'git -C /usercontent remote set-url origin "https://\$\{git_host_public\}/' "$ENTRYPOINT"; then
+  pass "remote set-url uses git_host_public (credentials removed from .git/config)"
+else
+  fail "remote set-url does not use git_host_public — credentials would leak into .git/config"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: no surviving echo line that prints the unscrubbed git_host
+#
+# The regex must NOT match git_host_public — it anchors on a word boundary
+# after git_host so that "git_host_public" is excluded.
+# ---------------------------------------------------------------------------
+unsafe_echo=$(grep -nE 'echo "Cloning repository:.*\$\{?git_host\}?[^_]' "$ENTRYPOINT" || true)
+if [ -z "$unsafe_echo" ]; then
+  pass "no echo line prints the unscrubbed git_host"
+else
+  fail "echo line still prints unscrubbed git_host: $unsafe_echo"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: no remote set-url that persists the unscrubbed git_host
+# ---------------------------------------------------------------------------
+unsafe_persist=$(grep -nE 'remote set-url origin "https://\$\{?git_host\}/' "$ENTRYPOINT" || true)
+if [ -z "$unsafe_persist" ]; then
+  pass "no remote set-url persists the unscrubbed git_host"
+else
+  fail "remote set-url still persists unscrubbed git_host: $unsafe_persist"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: behavioral verification — run the relevant fragment in a sandbox
+#
+# Simulate the git_host extraction logic for a Gitea-style SOURCE_URL and assert
+# that git_host_public has no '@' while git_host does. This catches regressions
+# where the sed expression is changed in a way that defeats the strip.
+# ---------------------------------------------------------------------------
+sandbox=$(bash -c '
+  url="https://oscadmin:abc123def@example.git.host/owner/repo.git"
+  git_host=$(echo "$url" | sed -E '"'"'s|https?://([^/]+).*|\1|'"'"')
+  git_host_public=$(echo "$git_host" | sed -E '"'"'s|^[^@]+@||'"'"')
+  echo "git_host=$git_host"
+  echo "git_host_public=$git_host_public"
+')
+
+if echo "$sandbox" | grep -q '^git_host=oscadmin:abc123def@example.git.host$' && \
+   echo "$sandbox" | grep -q '^git_host_public=example.git.host$'; then
+  pass "host-parsing on a Gitea-style URL strips creds in git_host_public only"
+else
+  fail "host-parsing sandbox produced unexpected output: $sandbox"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: behavioral verification — credential-less URL is unchanged
+# ---------------------------------------------------------------------------
+sandbox_plain=$(bash -c '
+  url="https://github.com/owner/repo.git"
+  git_host=$(echo "$url" | sed -E '"'"'s|https?://([^/]+).*|\1|'"'"')
+  git_host_public=$(echo "$git_host" | sed -E '"'"'s|^[^@]+@||'"'"')
+  echo "git_host=$git_host"
+  echo "git_host_public=$git_host_public"
+')
+
+if echo "$sandbox_plain" | grep -q '^git_host=github.com$' && \
+   echo "$sandbox_plain" | grep -q '^git_host_public=github.com$'; then
+  pass "host-parsing on a credential-less URL is a no-op (git_host_public == git_host)"
+else
+  fail "credential-less host-parsing produced unexpected output: $sandbox_plain"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

When `SOURCE_URL` embeds credentials in the Gitea format (`https://oscadmin:TOKEN@host/path.git`), the `clone_from_git()` function leaked the PAT in two places:

**1. Stdout / Loki logs**
The `echo "Cloning repository: ... from $git_host"` lines printed the credentialed host (`oscadmin:TOKEN@host`) directly into pod stdout, which is collected by Loki.

**2. `.git/config` on disk**
`git remote set-url origin "https://${git_host}/${repo_path}.git"` was intended to scrub the PAT from the git remote after cloning, but it reconstructed the same credentialed URL it was supposed to remove. Additionally, the scrub was only performed when `GIT_TOKEN` was set — Gitea apps that supply credentials via `SOURCE_URL` without a separate `GIT_TOKEN` received no scrub at all.

GitHub-hosted flows were unaffected because their `SOURCE_URL` has no embedded credentials; the token comes from the separate `GIT_TOKEN` env var.

## Fix

Introduce `git_host_public` by stripping any `user:pass@` prefix from `git_host` using `sed -E 's|^[^@]+@||'`. This mirrors the `GIT_HOST_PUBLIC="${GIT_HOST##*@}"` pattern used in the web-runner fix (see prior art below).

- All log lines now use `git_host_public` (credentials redacted to `***` when present)
- `git remote set-url` now unconditionally uses `git_host_public` after every fresh clone — not just when `GIT_TOKEN` is set
- The actual `git clone` retains the credentialed `git_host` for the Gitea path (no fallback token available), keeping auth intact
- For the `GIT_TOKEN` path, `git_host_public` is used in the clone URL too (credentials were never embedded there anyway)
- When `SOURCE_URL` has no embedded credentials, `git_host_public == git_host` and behavior is completely unchanged

## Prior art

This is the same fix applied to `Eyevinn/web-runner` in [PR #37](https://github.com/Eyevinn/web-runner/pull/37). The pattern is adapted from bash parameter expansion (`${GIT_HOST##*@}`) to sed (`sed -E 's|^[^@]+@||'`) to match python-runner's existing `sed`-based host extraction style.

## Tests

Added `tests/test-entrypoint-credential-scrub.sh` with six assertions:
1. `git_host_public` assignment exists and uses the correct sed expression
2. `remote set-url` uses `git_host_public`
3. No echo line prints the unscrubbed `git_host`
4. No `remote set-url` persists the unscrubbed `git_host`
5. Sandbox: Gitea-style URL strips credentials in `git_host_public` only
6. Sandbox: credential-less URL is a no-op (`git_host_public == git_host`)

All six pass locally.

🤖 Generated with [Claude Code](https://claude.ai/code)