### PR TITLE
feat: support #<ref> branch fragment and SUB_PATH for monorepo deployments

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -23,6 +23,14 @@ clone_from_git() {
   # When SOURCE_URL has no credentials, this is identical to git_host.
   local git_host_public=$(echo "$git_host" | sed -E 's|^[^@]+@||')
 
+  # Extract #<ref> fragment if present, and strip it from the URL used for
+  # further parsing. Must run before /tree/ handling so repo_path extraction
+  # operates on the fragment-stripped URL.
+  if [[ "$url" == *"#"* ]]; then
+    branch="${url##*#}"
+    url="${url%#*}"
+  fi
+
   # Check if URL contains a branch reference (e.g., /tree/branch_name)
   if [[ "$url" == *"/tree/"* ]]; then
     # Extract branch name (everything after /tree/)
@@ -144,6 +152,18 @@ fi
 
 # Change to the usercontent directory
 cd /usercontent
+
+# SUB_PATH support — for monorepo deployments where the Python app lives
+# in a subdirectory of the cloned repo.
+if [ -n "${SUB_PATH:-}" ]; then
+  WORK_DIR="/usercontent/$SUB_PATH"
+  if [ ! -d "$WORK_DIR" ]; then
+    echo "Error: SUB_PATH directory '$WORK_DIR' does not exist"
+    exit 1
+  fi
+  echo "Using SUB_PATH: $SUB_PATH (working directory: $WORK_DIR)"
+  cd "$WORK_DIR"
+fi
 
 # Load environment variables from config service if configured
 if [ -n "${OSC_ACCESS_TOKEN:-}" ] && [ -n "${CONFIG_SVC:-}" ]; then

--- a/tests/test-entrypoint-fragment-branch.sh
+++ b/tests/test-entrypoint-fragment-branch.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# tests/test-entrypoint-fragment-branch.sh
+#
+# Shell regression tests for the #<ref> URL fragment branch support added to
+# clone_from_git() in scripts/docker-entrypoint.sh.
+#
+# Background:
+#   The SOURCE_URL field accepts an optional fragment suffix to pin a specific
+#   Git ref, e.g.:
+#       https://github.com/org/repo.git#feature-branch
+#       https://github.com/org/repo.git#v1.2.3
+#
+#   The fragment must be stripped from the URL before any further path
+#   extraction occurs — otherwise the repo_path includes "#<ref>" as a literal
+#   string and the git clone URL becomes malformed.
+#
+#   If both a fragment AND a /tree/ path are present, /tree/ wins (overwrites
+#   branch) because the /tree/ block runs after the fragment-strip block.
+#
+# These tests combine grep-assertions on the entrypoint source (to verify the
+# fix is structurally present) with behavioral sandbox tests that execute just
+# the relevant logic in isolation.
+
+ENTRYPOINT="scripts/docker-entrypoint.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: the fragment-extraction block is present in the entrypoint
+# ---------------------------------------------------------------------------
+if grep -qE '\[\[ "\$url" == \*"#"\* \]\]' "$ENTRYPOINT"; then
+  pass "fragment-extraction guard '[[ \$url == *#* ]]' is present in entrypoint"
+else
+  fail "fragment-extraction block is missing from entrypoint"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: branch is set from the fragment using ##*# (strip up to last #)
+# ---------------------------------------------------------------------------
+if grep -qE 'branch="\$\{url##\*#\}"' "$ENTRYPOINT"; then
+  pass "branch assignment uses parameter expansion \${url##*#}"
+else
+  fail "branch assignment from fragment is missing or uses wrong syntax"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: URL is stripped of the fragment using %#* before /tree/ parsing
+# ---------------------------------------------------------------------------
+if grep -qE 'url="\$\{url%#\*\}"' "$ENTRYPOINT"; then
+  pass "URL fragment-strip uses parameter expansion \${url%#*}"
+else
+  fail "URL fragment-strip is missing or uses wrong syntax"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: fragment block appears BEFORE the /tree/ block in the file
+# ---------------------------------------------------------------------------
+line_fragment=$(grep -n '\[\[ "\$url" == \*"#"\* \]\]' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+line_tree=$(grep -n '"/tree/"' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+if [ -n "$line_fragment" ] && [ -n "$line_tree" ] && [ "$line_fragment" -lt "$line_tree" ]; then
+  pass "fragment block (line $line_fragment) appears before /tree/ block (line $line_tree)"
+else
+  fail "fragment block (line ${line_fragment:-?}) does not precede /tree/ block (line ${line_tree:-?})"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: behavioral — simple fragment sets branch and strips URL
+# ---------------------------------------------------------------------------
+result5=$(bash -c '
+  url="https://github.com/org/repo.git#feature-branch"
+  branch=""
+  if [[ "$url" == *"#"* ]]; then
+    branch="${url##*#}"
+    url="${url%#*}"
+  fi
+  echo "branch=$branch"
+  echo "url=$url"
+')
+if echo "$result5" | grep -q '^branch=feature-branch$' && \
+   echo "$result5" | grep -q '^url=https://github.com/org/repo.git$'; then
+  pass "fragment extraction: branch=feature-branch, URL has fragment stripped"
+else
+  fail "fragment extraction produced unexpected output: $result5"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: behavioral — tag fragment works the same way
+# ---------------------------------------------------------------------------
+result6=$(bash -c '
+  url="https://github.com/org/repo.git#v1.2.3"
+  branch=""
+  if [[ "$url" == *"#"* ]]; then
+    branch="${url##*#}"
+    url="${url%#*}"
+  fi
+  echo "branch=$branch"
+  echo "url=$url"
+')
+if echo "$result6" | grep -q '^branch=v1.2.3$' && \
+   echo "$result6" | grep -q '^url=https://github.com/org/repo.git$'; then
+  pass "tag fragment extraction: branch=v1.2.3, URL fragment stripped"
+else
+  fail "tag fragment extraction produced unexpected output: $result6"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: behavioral — URL without a fragment is unaffected
+# ---------------------------------------------------------------------------
+result7=$(bash -c '
+  url="https://github.com/org/repo.git"
+  branch=""
+  if [[ "$url" == *"#"* ]]; then
+    branch="${url##*#}"
+    url="${url%#*}"
+  fi
+  echo "branch=$branch"
+  echo "url=$url"
+')
+if echo "$result7" | grep -q '^branch=$' && \
+   echo "$result7" | grep -q '^url=https://github.com/org/repo.git$'; then
+  pass "URL without fragment leaves branch empty and URL unchanged"
+else
+  fail "URL without fragment produced unexpected output: $result7"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: behavioral — /tree/ wins over fragment (fragment sets branch first,
+#         then /tree/ block overwrites it, which is the documented behavior)
+# ---------------------------------------------------------------------------
+result8=$(bash -c '
+  url="https://github.com/org/repo/tree/main-branch#fragment-ref"
+  branch=""
+  # Fragment extraction (runs first)
+  if [[ "$url" == *"#"* ]]; then
+    branch="${url##*#}"
+    url="${url%#*}"
+  fi
+  # /tree/ block (overwrites branch)
+  if [[ "$url" == *"/tree/"* ]]; then
+    branch=$(echo "$url" | sed -E '"'"'s|.*/tree/||'"'"')
+  fi
+  echo "branch=$branch"
+')
+if echo "$result8" | grep -q '^branch=main-branch$'; then
+  pass "/tree/ block overwrites fragment branch (precedence: /tree/ > fragment)"
+else
+  fail "/tree/ precedence test produced unexpected output: $result8"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-entrypoint-subpath.sh
+++ b/tests/test-entrypoint-subpath.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# tests/test-entrypoint-subpath.sh
+#
+# Shell tests for the SUB_PATH monorepo subdirectory support added to
+# scripts/docker-entrypoint.sh.
+#
+# Background:
+#   In monorepo deployments, the Python application lives in a subdirectory
+#   of the cloned repository (e.g., backend/service). Without SUB_PATH support,
+#   the runner always starts from /usercontent, failing to find requirements.txt
+#   or any entry-point file.
+#
+#   When SUB_PATH is set, the runner changes into /usercontent/$SUB_PATH before
+#   pip install and detect_and_start(), so both operations see the correct CWD.
+#   A missing directory produces a clear error message and exits 1.
+#
+# These tests combine grep-assertions (structural presence) with behavioral
+# sandbox tests that simulate the SUB_PATH block in isolation using a temp dir.
+
+ENTRYPOINT="scripts/docker-entrypoint.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: SUB_PATH guard is present in the entrypoint
+# ---------------------------------------------------------------------------
+if grep -qE '\[ -n "\$\{SUB_PATH:-\}" \]' "$ENTRYPOINT"; then
+  pass "SUB_PATH guard '[ -n \"\${SUB_PATH:-}\" ]' is present in entrypoint"
+else
+  fail "SUB_PATH guard is missing from entrypoint"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: missing-directory error path exits 1
+# ---------------------------------------------------------------------------
+if grep -qE '! -d "\$WORK_DIR"' "$ENTRYPOINT" && grep -q 'exit 1' "$ENTRYPOINT"; then
+  pass "missing-directory check '! -d \$WORK_DIR' and exit 1 are present"
+else
+  fail "missing-directory check or exit 1 is missing from SUB_PATH block"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: SUB_PATH block appears after 'cd /usercontent' and before
+#         'Load environment variables from config service'
+# ---------------------------------------------------------------------------
+line_cd=$(grep -n '^cd /usercontent$' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+line_subpath=$(grep -n 'SUB_PATH support' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+line_config=$(grep -n 'Load environment variables from config service' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+
+if [ -n "$line_cd" ] && [ -n "$line_subpath" ] && [ -n "$line_config" ] && \
+   [ "$line_cd" -lt "$line_subpath" ] && [ "$line_subpath" -lt "$line_config" ]; then
+  pass "SUB_PATH block (line $line_subpath) is between cd /usercontent (line $line_cd) and config load (line $line_config)"
+else
+  fail "SUB_PATH block is not in the expected position: cd=$line_cd subpath=$line_subpath config=$line_config"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: behavioral — happy path: SUB_PATH set to an existing subdirectory
+# ---------------------------------------------------------------------------
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/backend/service"
+
+result4=$(bash -c "
+  SUB_PATH='backend/service'
+  USERCONTENT='$TMPDIR_TEST'
+  if [ -n \"\${SUB_PATH:-}\" ]; then
+    WORK_DIR=\"\$USERCONTENT/\$SUB_PATH\"
+    if [ ! -d \"\$WORK_DIR\" ]; then
+      echo 'Error: SUB_PATH directory does not exist'
+      exit 1
+    fi
+    echo \"Using SUB_PATH: \$SUB_PATH (working directory: \$WORK_DIR)\"
+    cd \"\$WORK_DIR\"
+  fi
+  echo \"cwd=\$(pwd)\"
+" 2>&1)
+exit4=$?
+
+rm -rf "$TMPDIR_TEST"
+
+if [ $exit4 -eq 0 ] && echo "$result4" | grep -q "Using SUB_PATH: backend/service" && \
+   echo "$result4" | grep -q "cwd="; then
+  pass "SUB_PATH happy path: cd into existing subdirectory succeeds"
+else
+  fail "SUB_PATH happy path failed (exit=$exit4): $result4"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: behavioral — error path: SUB_PATH set to a non-existent directory
+# ---------------------------------------------------------------------------
+TMPDIR_TEST2=$(mktemp -d)
+
+result5=$(bash -c "
+  SUB_PATH='nonexistent/path'
+  USERCONTENT='$TMPDIR_TEST2'
+  if [ -n \"\${SUB_PATH:-}\" ]; then
+    WORK_DIR=\"\$USERCONTENT/\$SUB_PATH\"
+    if [ ! -d \"\$WORK_DIR\" ]; then
+      echo \"Error: SUB_PATH directory '\$WORK_DIR' does not exist\"
+      exit 1
+    fi
+    cd \"\$WORK_DIR\"
+  fi
+  echo 'should not reach here'
+" 2>&1)
+exit5=$?
+
+rm -rf "$TMPDIR_TEST2"
+
+if [ $exit5 -eq 1 ] && echo "$result5" | grep -q "Error: SUB_PATH directory"; then
+  pass "SUB_PATH error path: missing directory produces error message and exit 1"
+else
+  fail "SUB_PATH error path failed (exit=$exit5, expected 1): $result5"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: behavioral — SUB_PATH unset: no cd into subdirectory
+# ---------------------------------------------------------------------------
+TMPDIR_TEST3=$(mktemp -d)
+
+result6=$(bash -c "
+  unset SUB_PATH
+  USERCONTENT='$TMPDIR_TEST3'
+  cd \"\$USERCONTENT\"
+  if [ -n \"\${SUB_PATH:-}\" ]; then
+    WORK_DIR=\"\$USERCONTENT/\$SUB_PATH\"
+    if [ ! -d \"\$WORK_DIR\" ]; then
+      echo 'Error: SUB_PATH directory does not exist'
+      exit 1
+    fi
+    cd \"\$WORK_DIR\"
+    echo 'entered subpath'
+  fi
+  echo \"cwd=\$(pwd)\"
+" 2>&1)
+exit6=$?
+
+rm -rf "$TMPDIR_TEST3"
+
+if [ $exit6 -eq 0 ] && ! echo "$result6" | grep -q 'entered subpath'; then
+  pass "SUB_PATH unset: block is skipped, working directory is unchanged"
+else
+  fail "SUB_PATH unset test produced unexpected output (exit=$exit6): $result6"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: behavioral — SUB_PATH set to empty string: block is skipped
+# ---------------------------------------------------------------------------
+TMPDIR_TEST4=$(mktemp -d)
+
+result7=$(bash -c "
+  SUB_PATH=''
+  USERCONTENT='$TMPDIR_TEST4'
+  cd \"\$USERCONTENT\"
+  if [ -n \"\${SUB_PATH:-}\" ]; then
+    WORK_DIR=\"\$USERCONTENT/\$SUB_PATH\"
+    if [ ! -d \"\$WORK_DIR\" ]; then
+      echo 'Error: SUB_PATH directory does not exist'
+      exit 1
+    fi
+    cd \"\$WORK_DIR\"
+    echo 'entered subpath'
+  fi
+  echo \"cwd=\$(pwd)\"
+" 2>&1)
+exit7=$?
+
+rm -rf "$TMPDIR_TEST4"
+
+if [ $exit7 -eq 0 ] && ! echo "$result7" | grep -q 'entered subpath'; then
+  pass "SUB_PATH empty string: block is skipped, working directory is unchanged"
+else
+  fail "SUB_PATH empty string test produced unexpected output (exit=$exit7): $result7"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes two feature gaps in the python-runner that prevent deployments from non-default Git branches or monorepo subdirectories.

- **Branch support**: `clone_from_git()` now extracts the `#<ref>` fragment from `SourceUrl` (e.g., `https://github.com/org/repo.git#feature-branch`) and passes it as `--branch <ref>` to git clone. Fragment is stripped from the URL before any further parsing, ensuring the existing `/tree/` handler continues to work.
- **Subdirectory support**: After cloning, if `SUB_PATH` is set (e.g., `SUB_PATH=backend/service`), the runner changes into `/usercontent/$SUB_PATH` before pip install and app detection. Missing directories produce a clear error message and exit 1.

This aligns python-runner with the web-runner, which already handles both features identically.

Closes #14. Linked: Eyevinn/osaas-deploy-manager#894.

**Note for birme**: After merging, the `eyevinn-osaas/python-runner` (prod) and `eyevinn-osaas-dev/python-runner` (dev) forks need to be synced. This is a standard manual fork-sync step.

## Test plan

- [ ] `tests/test-entrypoint-fragment-branch.sh` — 8 tests: fragment extraction sets correct branch, strips fragment from URL, `/tree/` takes precedence over fragment when both present
- [ ] `tests/test-entrypoint-subpath.sh` — 7 tests: SUB_PATH happy path (cd into existing directory), missing-directory error path (exit 1), unset/empty SUB_PATH skips the block

All 3 test files pass locally (21 tests total, 0 failures), including the existing `test-entrypoint-credential-scrub.sh` regression tests.

## Lessons

The `#<ref>` fragment must be stripped from the URL **before** the existing `/tree/` path-extraction logic runs — otherwise `repo_path` includes the fragment as a literal string and the git clone URL becomes malformed. The ordering of `/tree/` vs `#ref` handling is the non-obvious gotcha here: doing fragment-strip first is safer and matches web-runner behavior. When both forms appear in the same URL, `/tree/` wins because it runs second and overwrites the `branch` variable set by the fragment block.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>